### PR TITLE
Codebreak

### DIFF
--- a/Wiki/_toc.yml
+++ b/Wiki/_toc.yml
@@ -12,6 +12,7 @@ parts:
     - file: services/services-intro
     - file: services/services-help
     - file: services/services-one-on-one
+    - file: services/services-codebreak
     - file: services/services-conda
     - file: services/services-conda-updates
     - file: services/services-projects

--- a/Wiki/services/services-codebreak.md
+++ b/Wiki/services/services-codebreak.md
@@ -10,4 +10,4 @@ At the start of each session, we will ask you to provide a brief summary of your
 
 When appropriate we will take a few minutes at the beginning of a session to present a special topic which can include useful new software or language features, interesting blogs or highlight new developments in modelling. These topics will be announced beforehand as they arise.
 
-Please join the 'training-coe' mailing list to receive a weekly reminder for these sessions and info on what the special topic of the week is. If you would like to suggest a topic for us to cover (e.g. How do I use Git branches) please send an email to cws_help@nci.org.au and we will try to cover it in a future session.
+Please join the `training-coe` mailing list to receive a weekly reminder for these sessions and info on what the special topic of the week is. If you would like to suggest a topic for us to cover (e.g. How do I use Git branches) please send an email to cws_help@nci.org.au and we will try to cover it in a future session.

--- a/Wiki/services/services-codebreak.md
+++ b/Wiki/services/services-codebreak.md
@@ -1,0 +1,13 @@
+# Codebreak
+
+## Introduction
+
+The CMS team is running CodeBreak sessions every week.
+
+These sessions are an opportunity to come and have your questions answered by the CMS team, or to listen in to learn something new. Queries can be on some specific code you are writing, about a training you are trying to understand or broader questions about programming or scientific modelling.
+
+At the start of each session, we will ask you to provide a brief summary of your query so we can organise break-out rooms themed on topics, in order to make it possible to cover as many questions as possible and keep each room focussed on related problems. 
+
+When appropriate we will take a few minutes at the beginning of a session to present a special topic which can include useful new software or language features, interesting blogs or highlight new developments in modelling. These topics will be announced beforehand as they arise.
+
+Please join the 'training-coe' mailing list to receive a weekly reminder for these sessions and info on what the special topic of the week is. If you would like to suggest a topic for us to cover (e.g. How do I use Git branches) please send an email to cws_help@nci.org.au and we will try to cover it in a future session.

--- a/Wiki/services/services-help.md
+++ b/Wiki/services/services-help.md
@@ -11,7 +11,7 @@ The CMS team can be contacted for support through: 
 + The Climate Weather Science (CWS) helpdesk cws_help@nci.org.au
 + One-on-one [videocall](services-one-on-one.md)
 + In person meetings with local [CMS Team Members](../team.md)
-+ CodeBreak
++ CodeBreak [codebreak](services-codebreak.md)
 
 The CWS help desk is the preferred contact method as it allows the CMS team to prioritize queries so as to set aside time for other CMS duties, provides transparency of open requests to all CMS team members , and gives the CMS team flexibility to cover for team absences. Simply outline your issue in an email to cws_help@nci.org.au to open a ticket on our helpdesk.
 

--- a/Wiki/services/services-intro.md
+++ b/Wiki/services/services-intro.md
@@ -2,6 +2,8 @@
 
 **Index**
 
-[CWS Helpdesk](services-help.md)
+CWS Helpdesk [CWS Helpdesk](services-help.md)
 
 One-on-one [videocall](services-one-on-one.md)
+
+CodeBreak [codebreak](services-codebreak.md)


### PR DESCRIPTION
I just added a page with some info on codebreak, mostly copied from the old wiki. Also linked this page to a couple of the other services pages.  Left out the "CodeBreak sessions synopsis" part, will create an issue to see what to do with it.